### PR TITLE
fix README, build and install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,53 +14,7 @@ This tool may be especially useful for development and testing.
 To download a binary for the latest release, run:
 
 ```sh
-curl -sSfL https://raw.githubusercontent.com/ava-labs/camino-network-runner/main/scripts/install.sh | sh -s
-```
-
-The binary will be installed inside the `~/bin` directory.
-
-To add the binary to your path, run
-
-```sh
-export PATH=~/bin:$PATH
-```
-
-To add it to your path permanently, add an export command to your shell initialization script (ex: .bashrc).
-
-## Build from source code
-
-To download the binary into a specific directory, run:
-
-```sh
-curl -sSfL https://raw.githubusercontent.com/ava-labs/camino-network-runner/main/scripts/install.sh | sh -s -- -b <relative directory>
-```
-
-### Install using golang
-
-Requires golang to be installed on the system ([https://go.dev/doc/install](https://go.dev/doc/install)).
-
-### Download
-
-```sh
-go install github.com/chain4travel/camino-network-runner@latest
-```
-
-After that, the `camino-network-runner` binary should be present under the `$HOME/go/bin/` directory. Consider adding this directory to the `PATH` environment variable.
-
-### Install by release download
-
-Does not require golang to be installed on the system.
-
-Download the desired distribution from [https://github.com/chain4travel/camino-network-runner/releases](https://github.com/chain4travel/camino-network-runner/releases).
-
-Uncompress and locate where is convenient. Consider adding the target bin directory to the `PATH` environment variable.
-
-### Install from source code and execute tests
-
-#### Download
-
-```sh
-git clone https://github.com/chain4travel/camino-network-runner.git
+curl -sSfL https://raw.githubusercontent.com/chain4travel/camino-network-runner/chain4travel/scripts/install.sh | sh -s
 ```
 
 The binary will be installed inside the `./bin` directory.
@@ -71,7 +25,39 @@ To add the binary to your path, run
 export PATH=$PWD/bin:$PATH
 ```
 
-After that, `camino-network-runner` binary should be present under `$HOME/go/bin/` directory. Consider adding this directory to the `PATH` environment variable.
+To add it to your path permanently, add an export command to your shell initialization script (ex: .bashrc).
+
+#### Installing to a custom location
+
+To download the binary into a specific directory, run:
+
+```sh
+curl -sSfL https://raw.githubusercontent.com/chain4travel/camino-network-runner/chain4travel/scripts/install.sh | sh -s -- -b <directory>
+```
+
+### Build from source code
+
+#### Download
+
+```sh
+git clone https://github.com/chain4travel/camino-network-runner.git
+```
+
+#### Build
+
+From inside the cloned directory:
+
+```sh
+./scripts/build.sh
+```
+
+The binary will be installed inside the `./bin` directory.
+
+To add the binary to your path, run:
+
+```sh
+export PATH=$PWD/bin:$PATH
+```
 
 #### Run Unit Tests
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,4 +21,4 @@ fi
 # to pass this flag to all child processes spawned by the shell.
 export CGO_CFLAGS="-O -D__BLST_PORTABLE__"
 
-go build -v -ldflags="-X 'github.com/chain4travel/camino-network-runner/cmd.Version=$VERSION'" -o $OUTPUT/camino-network-runner
+go build -v -ldflags="-X 'github.com/ava-labs/avalanche-network-runner/cmd.Version=$VERSION'" -o $OUTPUT/camino-network-runner

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,12 +2,12 @@
 set -e
 
 PROJECT_NAME=camino-network-runner
-OWNER=ava-labs
+OWNER=chain4travel
 REPO="camino-network-runner"
 BINARY=camino-network-runner
 FORMAT=tar.gz
 PREFIX="$OWNER/$REPO"
-DEFAULT_INSTALL=~/bin
+DEFAULT_INSTALL=./bin
 
 usage() {
   this=$1
@@ -26,8 +26,8 @@ EOF
 }
 
 parse_args() {
-  #BINDIR is ./bin unless set be ENV
-  # over-ridden by flag below
+  # BINDIR is ./bin (set by DEFAULT_INSTALL above)
+  # unless over-ridden by ENV
 
   BINDIR=${BINDIR:-$DEFAULT_INSTALL}
   while getopts "b:dh?x" arg; do


### PR DESCRIPTION
- fix README for correct `install.sh` URL
- default to `./bin` as installation/build path in scripts
- fix `build.sh` version ldflag
- fix `install.sh` repo owner to chain4travel