### PR TITLE
TECH-531 start kopernikus network

### DIFF
--- a/scripts/kopernikus-network.sh
+++ b/scripts/kopernikus-network.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -e
+
+if ! [[ "$0" =~ scripts/kopernikus-network.sh ]]; then
+  echo "must be run from repository root"
+  exit 1
+fi
+
+COMMAND='start'
+CAMINO_EXEC_PATH='../camino-node/build/camino-node'
+if [ $# == 1 ]; then
+    COMMAND=$1
+else
+  if [ $# == 2 ]; then
+    COMMAND=$1
+    CAMINO_EXEC_PATH=$2
+  fi
+fi
+
+echo CAMINO_EXEC_PATH: ${CAMINO_EXEC_PATH}
+CAMINO_ROOT_PATH="${CAMINO_EXEC_PATH%/*/*}"
+
+if [ "$COMMAND" = 'start' ]; then
+  echo 'Starting network runner with kopernikus configuration...'
+  ./bin/camino-network-runner server &>/dev/null &
+  curl -X POST -k localhost:8081/v1/control/start -d '{"execPath":"'${CAMINO_EXEC_PATH}'","numNodes":2,"logLevel":"INFO","globalNodeConfig":"{\"http-host\":\"0.0.0.0\",\"network-id\":\"kopernikus\",\"genesis\":\"'${CAMINO_ROOT_PATH}'/dependencies/caminoethvm/caminogo/genesis/genesis_kopernikus.json\"}"}'
+else
+  echo 'Stopping network runner...'
+  curl -X POST -k localhost:8081/v1/control/stop
+fi


### PR DESCRIPTION
Contains a new sh script to boot up (/shutdown) a 2-node kopernikus network.
The script can take the following 2 optional arguments:
- command (start/stop)
- camino-nodeexec path
Default values are used in case none of them are provided.