### PR TITLE
New kopernikus genesis plus necessary adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,7 +869,7 @@ Later on the genesis contents can be used in network creation.
 
 ## Network Creation
 
-Th function `NewNetwork` returns a new network, parameterized on `network.Config`:
+The function `NewNetwork` returns a new network, parameterized on `network.Config`:
 
 ```go
 type Config struct {
@@ -899,6 +899,8 @@ The function that returns a new network may have additional configuration fields
 ## Default Network Creation
 
 The helper function `NewDefaultNetwork` returns a network using a pre-defined configuration. This allows users to create a new network without needing to define any configurations.
+
+If set, the environment variable ${NETWORK_ID} can be used to create a camino network based on a different genesis. Currently, the Kopernikus genesis is supported (by providing the appropriate NETOWORK_ID=1002).
 
 ```go
 // NewDefaultNetwork returns a new network using a pre-defined

--- a/local/network.go
+++ b/local/network.go
@@ -130,29 +130,31 @@ func init() {
 		panic(err)
 	}
 
-	startTime := time.Now().Unix()
-	lockTime := startTime + genesisLocktimeStartimeDelta
-	genesisMap["startTime"] = float64(startTime)
-	allocations, ok := genesisMap["allocations"].([]interface{})
-	if !ok {
-		panic(errors.New("could not get allocations in genesis"))
-	}
-	for _, allocIntf := range allocations {
-		alloc, ok := allocIntf.(map[string]interface{})
+	if !network.Kopernikus() {
+		startTime := time.Now().Unix()
+		lockTime := startTime + genesisLocktimeStartimeDelta
+		genesisMap["startTime"] = float64(startTime)
+		allocations, ok := genesisMap["allocations"].([]interface{})
 		if !ok {
-			panic(fmt.Errorf("unexpected type for allocation in genesis. got %T", allocIntf))
+			panic(errors.New("could not get allocations in genesis"))
 		}
-		unlockSchedule, ok := alloc["unlockSchedule"].([]interface{})
-		if !ok {
-			panic(errors.New("could not get unlockSchedule in allocation"))
-		}
-		for _, schedIntf := range unlockSchedule {
-			sched, ok := schedIntf.(map[string]interface{})
+		for _, allocIntf := range allocations {
+			alloc, ok := allocIntf.(map[string]interface{})
 			if !ok {
-				panic(fmt.Errorf("unexpected type for unlockSchedule elem in genesis. got %T", schedIntf))
+				panic(fmt.Errorf("unexpected type for allocation in genesis. got %T", allocIntf))
 			}
-			if _, ok := sched["locktime"]; ok {
-				sched["locktime"] = float64(lockTime)
+			unlockSchedule, ok := alloc["unlockSchedule"].([]interface{})
+			if !ok {
+				panic(errors.New("could not get unlockSchedule in allocation"))
+			}
+			for _, schedIntf := range unlockSchedule {
+				sched, ok := schedIntf.(map[string]interface{})
+				if !ok {
+					panic(fmt.Errorf("unexpected type for unlockSchedule elem in genesis. got %T", schedIntf))
+				}
+				if _, ok := sched["locktime"]; ok {
+					sched["locktime"] = float64(lockTime)
+				}
 			}
 		}
 	}

--- a/network/default/genesis.json
+++ b/network/default/genesis.json
@@ -76,39 +76,6 @@
     "lockModeBondDeposit": false,
     "initialAdmin": "X-local1g65uqn6t77p656w64023nh8nd9updzmxyymev2"
   },
-  "cChainGenesis": {
-    "config": {
-      "chainId": 43112,
-      "homesteadBlock": 0,
-      "daoForkBlock": 0,
-      "daoForkSupport": true,
-      "eip150Block": 0,
-      "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
-      "eip155Block": 0,
-      "eip158Block": 0,
-      "byzantiumBlock": 0,
-      "constantinopleBlock": 0,
-      "petersburgBlock": 0,
-      "istanbulBlock": 0,
-      "muirGlacierBlock": 0,
-      "apricotPhase1BlockTimestamp": 0,
-      "apricotPhase2BlockTimestamp": 0
-    },
-    "nonce": "0x0",
-    "timestamp": "0x0",
-    "extraData": "0x00",
-    "gasLimit": "0x5f5e100",
-    "difficulty": "0x0",
-    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "coinbase": "0x0000000000000000000000000000000000000000",
-    "alloc": {
-      "8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC": {
-        "balance": "0x295BE96E64066972000000"
-      }
-    },
-    "number": "0x0",
-    "gasUsed": "0x0",
-    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000"
-  },
+  "cChainGenesis": "{\"config\":{\"chainId\":43112,\"homesteadBlock\":0,\"daoForkBlock\":0,\"daoForkSupport\":true,\"eip150Block\":0,\"eip150Hash\":\"0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0\",\"eip155Block\":0,\"eip158Block\":0,\"byzantiumBlock\":0,\"constantinopleBlock\":0,\"petersburgBlock\":0,\"istanbulBlock\":0,\"muirGlacierBlock\":0,\"apricotPhase1BlockTimestamp\":0,\"apricotPhase2BlockTimestamp\":0},\"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC\":{\"balance\":\"0x295BE96E64066972000000\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
   "message": "{{ fun_quote }}"
 }

--- a/network/default/genesis_kopernikus.json
+++ b/network/default/genesis_kopernikus.json
@@ -1,0 +1,172 @@
+{
+  "networkID": 1002,
+  "camino": {
+    "verifyNodeSignature": true,
+    "lockModeBondDeposit": true,
+    "initialAdmin": "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3",
+    "depositOffers": [
+      {
+        "offerID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi",
+        "interestRateNominator": 80000,
+        "startOffset": 0,
+        "endOffset": 112795200,
+        "minAmount": 1,
+        "minDuration": 110376000,
+        "maxDuration": 110376000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
+        "flags": {
+          "locked": true
+        }
+      },
+      {
+        "offerID": "2AySgbKZp8PP95KCsttY68uKJyFbsATHnE73jk1P9fSppmqV45",
+        "interestRateNominator": 0,
+        "startOffset": 0,
+        "endOffset": 160099200,
+        "minAmount": 1,
+        "minDuration": 157680000,
+        "maxDuration": 157680000,
+        "unlockPeriodDuration": 63072000,
+        "noRewardsPeriodDuration": 31536000,
+        "flags": {
+          "locked": true
+        }
+      },
+      {
+        "offerID": "2uGR8giEWip1mGWQzF1DXNVpUXY8M1futjhVErqV7uJntHmWrh",
+        "interestRateNominator": 90000,
+        "startOffset": 0,
+        "endOffset": 144331200,
+        "minAmount": 1,
+        "minDuration": 141912000,
+        "maxDuration": 141912000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
+        "flags": {
+          "locked": true
+        }
+      },
+      {
+        "offerID": "2ad2QNdpDQWGUMx7WWRwAG1bxFwx5amEZzfoqGrGF1D7N3HNLp",
+        "interestRateNominator": 100000,
+        "startOffset": 0,
+        "endOffset": 175867200,
+        "minAmount": 1,
+        "minDuration": 173448000,
+        "maxDuration": 173448000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
+        "flags": {
+          "locked": true
+        }
+      },
+      {
+        "offerID": "k5VaqN4kFtcKQWfjyJpk4YA8VBwW7TyeRicDGsdzRNRNSG1R1",
+        "interestRateNominator": 90000,
+        "startOffset": 0,
+        "endOffset": 32745600,
+        "minAmount": 1,
+        "minDuration": 31536000,
+        "maxDuration": 31536000,
+        "unlockPeriodDuration": 31536000,
+        "noRewardsPeriodDuration": 15768000,
+        "flags": {
+          "locked": true
+        }
+      },
+      {
+        "offerID": "2vGw1ZaUWWGxhAm69Dt13zw5sUvmtCbzVTvvzPp34Ch5qEznBg",
+        "interestRateNominator": 110000,
+        "startOffset": 0,
+        "endOffset": 64281600,
+        "minAmount": 1,
+        "minDuration": 60,
+        "maxDuration": 31536000,
+        "unlockPeriodDuration": 0,
+        "noRewardsPeriodDuration": 0,
+        "flags": {
+          "locked": false
+        }
+      },
+      {
+        "offerID": "24zEuyv4zBvF2pGPbzwVYhCxPQUfuqD4pWDRfJrJapXBhFfxDh",
+        "interestRateNominator": 210000,
+        "startOffset": 0,
+        "endOffset": 64281600,
+        "minAmount": 1,
+        "minDuration": 86400,
+        "maxDuration": 31536000,
+        "unlockPeriodDuration": 43200,
+        "noRewardsPeriodDuration": 43200,
+        "flags": {
+          "locked": false
+        }
+      }
+    ],
+    "allocations": [
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3",
+        "xAmount": 988990000000000000,
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 4000000000000,
+            "nodeID": "NodeID-AK7sPBsZM9rQwse23aLhEEBPHZD5gkLrL",
+            "validatorDuration": 31536000,
+            "depositDuration": 110376000,
+            "timestampOffset": 0,
+            "depositOfferID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi",
+            "memo": "KOPERNIKUS"
+          },
+          {
+            "amount": 10000000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 0,
+            "depositOfferID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi"
+          },
+          {
+            "amount": 4000000000000
+          }
+
+        ]
+      },
+      {
+        "ethAddr": "0x0000000000000000000000000000000000000000",
+        "avaxAddr": "X-kopernikus18jma8ppw3nhx5r4ap8clazz0dps7rv5uuvjh68",
+        "addressStates": {
+          "consortiumMember": true,
+          "kycVerified": true
+        },
+        "platformAllocations": [
+          {
+            "amount": 400000000000000
+          },
+          {
+            "amount": 600000000000000,
+            "depositDuration": 110376000,
+            "timestampOffset": 0,
+            "depositOfferID": "2SAadCwUEjHWfZEiK2DgRNQTE4YHgT8guTvmhB4uJDswabvvsi"
+          }
+        ]
+      }
+    ],
+    "initialMultisigAddresses": [
+      {
+        "alias": "X-kopernikus1fq0jc8svlyazhygkj0s36qnl6s0km0h3uuc99w",
+        "addresses": [
+          "X-kopernikus1g65uqn6t77p656w64023nh8nd9updzmxh8ttv3"
+        ],
+        "threshold": 1
+      }
+    ]
+  },
+  "startTime": 1671058800,
+  "initialStakeDurationOffset": 0,
+  "cChainGenesis": "{\"config\":{\"chainId\":502},\"initialAdmin\":\"0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC\", \"nonce\":\"0x0\",\"timestamp\":\"0x0\",\"extraData\":\"0x00\",\"gasLimit\":\"0x5f5e100\",\"difficulty\":\"0x0\",\"mixHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"coinbase\":\"0x0000000000000000000000000000000000000000\",\"alloc\":{\"0100000000000000000000000000000000000000\":{\"code\":\"0x7300000000000000000000000000000000000000003014608060405260043610603d5760003560e01c80631e010439146042578063b6510bb314606e575b600080fd5b605c60048036036020811015605657600080fd5b503560b1565b60408051918252519081900360200190f35b818015607957600080fd5b5060af60048036036080811015608e57600080fd5b506001600160a01b03813516906020810135906040810135906060013560b6565b005b30cd90565b836001600160a01b031681836108fc8690811502906040516000604051808303818888878c8acf9550505050505015801560f4573d6000803e3d6000fd5b505050505056fea26469706673582212201eebce970fe3f5cb96bf8ac6ba5f5c133fc2908ae3dcd51082cfee8f583429d064736f6c634300060a0033\",\"balance\":\"0x0\"}, \"0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC\":{\"balance\":\"0x56BC75E2D63100000\"}},\"number\":\"0x0\",\"gasUsed\":\"0x0\",\"parentHash\":\"0x0000000000000000000000000000000000000000000000000000000000000000\"}",
+  "message": "Have a nice trip!"
+}


### PR DESCRIPTION
Added support for booting up camino compatible networks. The env var NETWORK_ID can be used to reference for instance a kopernikus genesis (1002).