### PR TITLE
[E2E] Adjusted interestRateNominator for presale1min

### DIFF
--- a/examples/local/e2enodenetwork/main.go
+++ b/examples/local/e2enodenetwork/main.go
@@ -209,7 +209,7 @@ func postProcessConfig(config *network.Config) {
 	// presale1min offer
 	depositOffers = append(depositOffers, map[string]interface{}{
 		"memo":                    "presale1min",
-		"interestRateNominator":   80000,
+		"interestRateNominator":   0.1 * 1_000_000 * (365 * 24 * 60 * 60),
 		"startOffset":             0,
 		"endOffset":               112795200,
 		"minAmount":               100,


### PR DESCRIPTION
## Why this should be merged
Adjusted interestRateNominator to produce a CAM amount which is not rounded to 0.

## How this works
Change in deposit offer 'presale1min'

## How this was tested
Both manually and via automatic pipeline tests.
