### PR TITLE
TECH-535-Local-Network-Preparation

### DIFF
--- a/network/genesis.go
+++ b/network/genesis.go
@@ -7,12 +7,15 @@ import (
 	"math/big"
 	"os"
 
+	"github.com/ava-labs/avalanche-network-runner/utils/constants"
+
 	coreth_params "github.com/ava-labs/coreth/params"
 )
 
 // PrivateKey-12bQFG6mSUVLsq2H1EAxGbu8p6mYi7zEA7QvQzJezL12JS8j5 -> X-kopernikus1zy075lddftstzpwzvt627mvc0tep0vyk7y9v4l
 // PrivateKey-BhnbhFKyDjhW8r3v9ZY6wPWkrAphTVPzniLjLrviZV8ndHMBe -> X-kopernikus1lx58kettrnt2kyr38adyrrmxt5x57u4vg4cfky
 // PrivateKey-Ge71NJhUY3TjZ9dLohijSnNq46QxobjqxHGMUDAPoVsNFA93w -> X-kopernikus13kyf72ftu4l77kss7xm0kshm0au29s48zjaygq
+//
 //go:embed default/genesis.json
 var genesisBytes []byte
 
@@ -33,6 +36,7 @@ func LoadLocalGenesis() (map[string]interface{}, error) {
 	corethCChainGenesis := coreth_params.AvalancheLocalChainConfig
 	if _, ok := os.LookupEnv("CAMINO_NETWORK"); ok {
 		corethCChainGenesis.SunrisePhase0BlockTimestamp = big.NewInt(0)
+		corethCChainGenesis.ChainID = constants.CaminoLocalChainID
 	}
 
 	// but the part in coreth is only the "config" part.

--- a/utils/constants/camino_constants.go
+++ b/utils/constants/camino_constants.go
@@ -1,0 +1,9 @@
+package constants
+
+import (
+	"math/big"
+)
+
+// CaminoLocalChainID Used in the local network. Necessary to set the chainID to a value other than the default,
+// otherwise the local network will give deployment permissions to every address no matter its role value.
+var CaminoLocalChainID = big.NewInt(503)


### PR DESCRIPTION
## Why this should be merged
To add necessary changes for local network regarding the Multi Role E2E Test [PR#34](https://github.com/chain4travel/caminojs/pull/54)

## How this works
Local network's ChainID get a default value and with that value local network sets up deployment to be doable from all users, no matter their role/state. This PR consists of the following changes:

- adds a CaminoLocalChainID variable in camino_constants.go
- inserts the value of this variable as the local network's Chain ID in order to avoid making network's deployment available for all.

## How this was tested
Both manually and via automatic pipeline tests.