### PR TITLE
[E2E] Configured feeRewardExportMinAmount and feeRewardExportMinTimeInterval to facilitate testing

### DIFF
--- a/examples/local/e2enodenetwork/main.go
+++ b/examples/local/e2enodenetwork/main.go
@@ -370,6 +370,8 @@ func postProcessConfig(config *network.Config) {
 	camino["allocations"] = allocations
 
 	cChainGenesis["initialAdmin"] = "0x1f0e5c64afdf53175f78846f7125776e76fa8f34"
+	cChainGenesis["feeRewardExportMinAmount"] = "0x2710"     // 10000
+	cChainGenesis["feeRewardExportMinTimeInterval"] = "0x3C" // 60sec (must be at least 1min because of the SharedMemorySyncBound)
 
 	alloc["1f0e5c64afdf53175f78846f7125776e76fa8f34"] = map[string]interface{}{ // adminAddress
 		"balance": "0x295BE96E64066972000000",


### PR DESCRIPTION
## Why this should be merged
Default values for the flags `feeRewardExportMinAmount` and `feeRewardExportMinTimeInterval` do not allow for reasonable e2e tests. Therefore, genesis flags have been introduced for these values. This PR sets values for these flags only in the context of the `e2enodenetwork`

## How this works
 Configured `feeRewardExportMinAmount` and `feeRewardExportMinTimeInterval` to facilitate testing.

## How this was tested
Both manually and e2e tests implemented in caminojs.
