### PR TITLE
[FLAGS] Add new flag http-insecure-localhost in e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/ava-labs/avalanchego => github.com/chain4travel/caminogo v0.4.9-rc2.0.20230526125621-0adfa80bd7c4
+replace github.com/ava-labs/avalanchego => github.com/chain4travel/caminogo v0.4.10-rc1
 
-replace github.com/ava-labs/coreth => github.com/chain4travel/caminoethvm v0.4.9-rc2.0.20230526130535-51a4ecc55666
+replace github.com/ava-labs/coreth => github.com/chain4travel/caminoethvm v0.4.10-rc1

--- a/go.sum
+++ b/go.sum
@@ -92,10 +92,10 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chain4travel/caminoethvm v0.4.9-rc2.0.20230526130535-51a4ecc55666 h1:3lTdpuAj8L/vgKAThJtJKNYM2H8l/1B6sBO+boQitPU=
-github.com/chain4travel/caminoethvm v0.4.9-rc2.0.20230526130535-51a4ecc55666/go.mod h1:by2qvlczT7RHcrnOjP/e190V/U+tAKbIFsfd/qhjTB8=
-github.com/chain4travel/caminogo v0.4.9-rc2.0.20230526125621-0adfa80bd7c4 h1:hW6TD2TBr62LbjrxGGG0ECAAbCvecbI2jyiqrlQy0mM=
-github.com/chain4travel/caminogo v0.4.9-rc2.0.20230526125621-0adfa80bd7c4/go.mod h1:q1rl0Dh8bmdUw9KKLEYxlJqGFPlbvTPPTAJLV/JgoR4=
+github.com/chain4travel/caminoethvm v0.4.10-rc1 h1:vmdiFQBLr77p6qen0DHSGy15ma//ia6uDtqlBFkwxDA=
+github.com/chain4travel/caminoethvm v0.4.10-rc1/go.mod h1:by2qvlczT7RHcrnOjP/e190V/U+tAKbIFsfd/qhjTB8=
+github.com/chain4travel/caminogo v0.4.10-rc1 h1:aDcwAKktLC3s1RBpO85Ju4wxjaZ7hcInsaT78bQP/D4=
+github.com/chain4travel/caminogo v0.4.10-rc1/go.mod h1:q1rl0Dh8bmdUw9KKLEYxlJqGFPlbvTPPTAJLV/JgoR4=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/local/default/flags.json
+++ b/local/default/flags.json
@@ -3,7 +3,7 @@
   "network-max-reconnect-delay":"1s",
   "public-ip":"127.0.0.1",
   "health-check-frequency":"2s",
-  "api-admin-enabled":true,
+  "api-admin-enabled":false,
   "api-ipcs-enabled":true,
   "index-enabled":true,
   "log-display-level":"ERROR",

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -9,8 +9,8 @@ if ! [[ "$0" =~ scripts/tests.e2e.sh ]]; then
   exit 255
 fi
 
-DEFAULT_VERSION_1=0.4.9-rc2
-DEFAULT_VERSION_2=0.4.1-rc2
+DEFAULT_VERSION_1=0.4.10-rc1
+DEFAULT_VERSION_2=0.4.10-rc1
 
 if [ $# == 0 ]; then
     VERSION_1=$DEFAULT_VERSION_1
@@ -34,65 +34,65 @@ echo "Running e2e tests with:"
 echo VERSION_1: ${VERSION_1}
 echo VERSION_2: ${VERSION_2}
 
-if [ ! -f /tmp/camino-node-v${VERSION_1}/camino-node ]
-then
-    ############################
-    # download camino-node
-    # https://github.com/chain4travel/camino-node/releases
-    GOARCH=$(go env GOARCH)
-    GOOS=$(go env GOOS)
-    DOWNLOAD_URL=https://github.com/chain4travel/camino-node/releases/download/v${VERSION_1}/camino-node-linux-${GOARCH}-v${VERSION_1}.tar.gz
-    DOWNLOAD_PATH=/tmp/camino-node.tar.gz
-    if [[ ${GOOS} == "darwin" ]]; then
-      DOWNLOAD_URL=https://github.com/chain4travel/camino-node/releases/download/v${VERSION_1}/camino-node-macos-v${VERSION_1}.zip
-      DOWNLOAD_PATH=/tmp/camino-node.zip
-    fi
-
-    rm -rf /tmp/camino-node-v${VERSION_1}
-    rm -rf /tmp/camino-node-build
-    rm -f ${DOWNLOAD_PATH}
-
-    echo "downloading camino-node ${VERSION_1} at ${DOWNLOAD_URL}"
-    curl -L ${DOWNLOAD_URL} -o ${DOWNLOAD_PATH}
-
-    echo "extracting downloaded camino-node"
-    if [[ ${GOOS} == "linux" ]]; then
-      tar xzvf ${DOWNLOAD_PATH} -C /tmp
-    elif [[ ${GOOS} == "darwin" ]]; then
-      unzip ${DOWNLOAD_PATH} -d /tmp/camino-node-build
-      mv /tmp/camino-node-build/build /tmp/camino-node-v${VERSION_1}
-    fi
-fi
-
-if [ ! -f /tmp/camino-node-v${VERSION_2}/camino-node ]
-then
-    ############################
-    # download camino-node
-    # https://github.com/chain4travel/camino-node/releases
-    GOARCH=$(go env GOARCH)
-    GOOS=$(go env GOOS)
-    DOWNLOAD_URL=https://github.com/chain4travel/camino-node/releases/download/v${VERSION_2}/camino-node-linux-${GOARCH}-v${VERSION_2}.tar.gz
-    DOWNLOAD_PATH=/tmp/camino-node.tar.gz
-    if [[ ${GOOS} == "darwin" ]]; then
-      DOWNLOAD_URL=https://github.com/chain4travel/camino-node/releases/download/v${VERSION_2}/camino-node-macos-v${VERSION_2}.zip
-      DOWNLOAD_PATH=/tmp/camino-node.zip
-    fi
-
-    rm -rf /tmp/camino-node-v${VERSION_2}
-    rm -rf /tmp/camino-node-build
-    rm -f ${DOWNLOAD_PATH}
-
-    echo "downloading camino-node ${VERSION_2} at ${DOWNLOAD_URL}"
-    curl -L ${DOWNLOAD_URL} -o ${DOWNLOAD_PATH}
-
-    echo "extracting downloaded camino-node"
-    if [[ ${GOOS} == "linux" ]]; then
-      tar xzvf ${DOWNLOAD_PATH} -C /tmp
-    elif [[ ${GOOS} == "darwin" ]]; then
-      unzip ${DOWNLOAD_PATH} -d /tmp/camino-node-build
-      mv /tmp/camino-node-build/build /tmp/camino-node-v${VERSION_2}
-    fi
-fi
+#if [ ! -f /tmp/camino-node-v${VERSION_1}/camino-node ]
+#then
+#    ############################
+#    # download camino-node
+#    # https://github.com/chain4travel/camino-node/releases
+#    GOARCH=$(go env GOARCH)
+#    GOOS=$(go env GOOS)
+#    DOWNLOAD_URL=https://github.com/chain4travel/camino-node/releases/download/v${VERSION_1}/camino-node-linux-${GOARCH}-v${VERSION_1}.tar.gz
+#    DOWNLOAD_PATH=/tmp/camino-node.tar.gz
+#    if [[ ${GOOS} == "darwin" ]]; then
+#      DOWNLOAD_URL=https://github.com/chain4travel/camino-node/releases/download/v${VERSION_1}/camino-node-macos-v${VERSION_1}.zip
+#      DOWNLOAD_PATH=/tmp/camino-node.zip
+#    fi
+#
+#    rm -rf /tmp/camino-node-v${VERSION_1}
+#    rm -rf /tmp/camino-node-build
+#    rm -f ${DOWNLOAD_PATH}
+#
+#    echo "downloading camino-node ${VERSION_1} at ${DOWNLOAD_URL}"
+#    curl -L ${DOWNLOAD_URL} -o ${DOWNLOAD_PATH}
+#
+#    echo "extracting downloaded camino-node"
+#    if [[ ${GOOS} == "linux" ]]; then
+#      tar xzvf ${DOWNLOAD_PATH} -C /tmp
+#    elif [[ ${GOOS} == "darwin" ]]; then
+#      unzip ${DOWNLOAD_PATH} -d /tmp/camino-node-build
+#      mv /tmp/camino-node-build/build /tmp/camino-node-v${VERSION_1}
+#    fi
+#fi
+#
+#if [ ! -f /tmp/camino-node-v${VERSION_2}/camino-node ]
+#then
+#    ############################
+#    # download camino-node
+#    # https://github.com/chain4travel/camino-node/releases
+#    GOARCH=$(go env GOARCH)
+#    GOOS=$(go env GOOS)
+#    DOWNLOAD_URL=https://github.com/chain4travel/camino-node/releases/download/v${VERSION_2}/camino-node-linux-${GOARCH}-v${VERSION_2}.tar.gz
+#    DOWNLOAD_PATH=/tmp/camino-node.tar.gz
+#    if [[ ${GOOS} == "darwin" ]]; then
+#      DOWNLOAD_URL=https://github.com/chain4travel/camino-node/releases/download/v${VERSION_2}/camino-node-macos-v${VERSION_2}.zip
+#      DOWNLOAD_PATH=/tmp/camino-node.zip
+#    fi
+#
+#    rm -rf /tmp/camino-node-v${VERSION_2}
+#    rm -rf /tmp/camino-node-build
+#    rm -f ${DOWNLOAD_PATH}
+#
+#    echo "downloading camino-node ${VERSION_2} at ${DOWNLOAD_URL}"
+#    curl -L ${DOWNLOAD_URL} -o ${DOWNLOAD_PATH}
+#
+#    echo "extracting downloaded camino-node"
+#    if [[ ${GOOS} == "linux" ]]; then
+#      tar xzvf ${DOWNLOAD_PATH} -C /tmp
+#    elif [[ ${GOOS} == "darwin" ]]; then
+#      unzip ${DOWNLOAD_PATH} -d /tmp/camino-node-build
+#      mv /tmp/camino-node-build/build /tmp/camino-node-v${VERSION_2}
+#    fi
+#fi
 
 ############################
 echo "building runner"
@@ -132,8 +132,8 @@ echo "running e2e tests"
 --log-level debug \
 --grpc-endpoint="0.0.0.0:8080" \
 --grpc-gateway-endpoint="0.0.0.0:8081" \
---camino-node-path-1=/tmp/camino-node-v${VERSION_1}/camino-node \
---camino-node-path-2=/tmp/camino-node-v${VERSION_2}/camino-node
+--camino-node-path-1=/home/kkyriakis/dev/c4t/camino-node/build/camino-node
+#--camino-node-path-2=/tmp/camino-node-v${VERSION_2}/camino-node
 
 kill ${PID}
 echo "ALL SUCCESS!"

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -57,9 +57,9 @@ var (
 	pausedNodeURI     = ""
 	pausedNodeName    = "node1"
 	customNodeConfigs = map[string]string{
-		"node1": `{"api-admin-enabled":true}`,
-		"node2": `{"api-admin-enabled":true}`,
-		"node3": `{"api-admin-enabled":true}`,
+		"node1": `{"api-admin-enabled":true, "http-insecure-localhost": true}`,
+		"node2": `{"api-admin-enabled":true, "http-insecure-localhost": true}`,
+		"node3": `{"api-admin-enabled":true, "http-insecure-localhost": true}`,
 		"node4": `{"api-admin-enabled":false}`,
 		"node5": `{"api-admin-enabled":false}`,
 		"node6": `{"api-admin-enabled":false}`,


### PR DESCRIPTION
## Why this should be merged
To fix e2e tests after the introduction of a new node flag called 'http-insecure-localhost' which prevents a node from running with  default `http-host` and `api-admin-enabled`. Furthermore, the node version used for e2e tests needs to be accordingly updated.

## How this works
Adds the `http-insecure-localhost` flag to the e2e test cases using the Admin API and switches the API of for the default local setup.
Also bumps node version to v0.4.10-rc1

## How this was tested
With e2e tests against latest status of dev branch in camino-node. E2e tests should be ignored until new node version is available.